### PR TITLE
Added S3 Origin HTTP OPTION Method

### DIFF
--- a/app/pkg/lambda/lambda.go
+++ b/app/pkg/lambda/lambda.go
@@ -79,6 +79,10 @@ func (handler Handler) Bootstrap(event *events.LambdaFunctionURLRequest) (*event
 		web.SupportedMethods = strings.Split(httpAllowedMethods, ",")
 	}
 
+	if strings.ToUpper(method) == "OPTIONS" {
+		return web.ResponseOptions(httpAllowedMethods), nil
+	}
+
 	if web.NotImplemented(method) {
 		return web.Response501(), nil
 	}

--- a/app/pkg/lambda/lambda.go
+++ b/app/pkg/lambda/lambda.go
@@ -74,6 +74,10 @@ func (handler Handler) Bootstrap(event *events.LambdaFunctionURLRequest) (*event
 	log.Infof("handler started")
 
 	method := event.RequestContext.HTTP.Method
+	httpAllowedMethods, ok := os.LookupEnv("HTTP_METHODS_ALLOWED")
+	if ok {
+		web.SupportedMethods = strings.Split(httpAllowedMethods, ",")
+	}
 
 	if web.NotImplemented(method) {
 		return web.Response501(), nil

--- a/app/pkg/web/page.go
+++ b/app/pkg/web/page.go
@@ -195,3 +195,15 @@ func RespondJSON(content interface{}) (*events.LambdaFunctionURLResponse, error)
 
 	return Respond200(jsonEncodedContent, contentTypeJson), nil
 }
+
+// ResponseOptions Send a HTTP methods allowed response for an HTTP OPTIONS
+// request.
+func ResponseOptions(options string) *events.LambdaFunctionURLResponse {
+	return &events.LambdaFunctionURLResponse{
+		Body: http501NotImplemented,
+		Headers: cli.StringMap{
+			"Allow": options,
+		},
+		StatusCode: 204,
+	}
+}

--- a/app/pkg/web/server.go
+++ b/app/pkg/web/server.go
@@ -21,7 +21,7 @@ type Response struct {
 
 // This simple server does not implement these methods. You must provide your
 // own code to serve these methods.
-var supportedMethods = []string{
+var SupportedMethods = []string{
 	"GET",
 	"POST",
 }
@@ -84,7 +84,7 @@ func LoadFile(pagePath, contentType string) (*events.LambdaFunctionURLResponse, 
 // and false otherwise.
 func NotImplemented(method string) bool {
 	missing := true
-	for _, sm := range supportedMethods {
+	for _, sm := range SupportedMethods {
 		if strings.EqualFold(sm, method) {
 			missing = false
 		}

--- a/main-lambda.tf
+++ b/main-lambda.tf
@@ -1,10 +1,10 @@
 locals {
   alt_domain_names = length(var.alt_domain_names) > 0 ? join(",", var.alt_domain_names) : ""
   required_vars = {
-    REDIRECT_TO    = var.domain_name
-    REDIRECT_HOSTS = local.alt_domain_names
-    S3_BUCKET_NAME = aws_s3_bucket.web.id
-    Authorization  = local.authorization_header
+    REDIRECT_TO          = var.domain_name
+    REDIRECT_HOSTS       = local.alt_domain_names
+    S3_BUCKET_NAME       = aws_s3_bucket.web.id
+    Authorization        = local.authorization_header
     HTTP_METHODS_ALLOWED = join(",", var.cf_allowed_methods)
   }
   lf_environment_vars = merge(local.required_vars, var.lf_environment_vars)

--- a/main-lambda.tf
+++ b/main-lambda.tf
@@ -5,6 +5,7 @@ locals {
     REDIRECT_HOSTS = local.alt_domain_names
     S3_BUCKET_NAME = aws_s3_bucket.web.id
     Authorization  = local.authorization_header
+    HTTP_METHODS_ALLOWED = join(",", var.cf_allowed_methods)
   }
   lf_environment_vars = merge(local.required_vars, var.lf_environment_vars)
 

--- a/main.tf
+++ b/main.tf
@@ -162,10 +162,10 @@ resource "aws_cloudfront_distribution" "web" {
   }
 
   ordered_cache_behavior { # S3 cache behavior
-    allowed_methods = ["GET", "HEAD"]
+    allowed_methods = ["GET", "HEAD", "OPTIONS"]
     #    cache_policy_id          = length(data.aws_cloudfront_cache_policy.web) > 0 ? data.aws_cloudfront_cache_policy.web[0].id : aws_cloudfront_cache_policy.web.id
     compress       = var.cf_compress
-    cached_methods = ["GET", "HEAD"]
+    cached_methods = ["GET", "HEAD", "OPTIONS"]
     #    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.web.id
     path_pattern           = var.cf_path_pattern
     target_origin_id       = local.cf_s3_origin_id

--- a/tests/02-redirect-apex-to-subdomain.tftest.hcl
+++ b/tests/02-redirect-apex-to-subdomain.tftest.hcl
@@ -8,12 +8,13 @@ variables {
 
 run "execute" {
   variables {
-    alt_domain_names = ["terraform-02.test.kohirens.com"]
-    aws_region       = "us-east-1"
-    domain_name      = "www.terraform-02.test.kohirens.com"
-    force_destroy    = true
-    iac_source       = "github.com/kohirens/aws-tf-s3-website"
-    lf_source_zip    = "./app/bootstrap.zip"
+    alt_domain_names   = ["terraform-02.test.kohirens.com"]
+    aws_region         = "us-east-1"
+    domain_name        = "www.terraform-02.test.kohirens.com"
+    force_destroy      = true
+    iac_source         = "github.com/kohirens/aws-tf-s3-website"
+    lf_source_zip      = "./app/bootstrap.zip"
+    cf_allowed_methods = ["GET", "HEAD", "OPTIONS"]
   }
 }
 
@@ -39,5 +40,10 @@ run "verify_domain_redirect" {
   assert {
     condition     = "hi world!" == terraform_data.www_no_redirect_loop.output.response_body
     error_message = "incorrect response body for the index.html page"
+  }
+
+  assert {
+    condition     = strcontains(data.local_file.get_options.content, "allow: GET,HEAD,OPTIONS")
+    error_message = "failed to get expected options status code"
   }
 }

--- a/tests/02-redirect-apex/main.tf
+++ b/tests/02-redirect-apex/main.tf
@@ -94,3 +94,26 @@ resource "terraform_data" "www_no_redirect_loop" {
 
   input = jsondecode(data.local_file.www_no_redirect_loop.content)
 }
+
+locals {
+  test_script = "${path.module}/../testdata/test-endpoint.sh"
+  get_options = "${path.module}/${replace(var.domain_name, ".", "-")}-options.json"
+}
+
+resource "null_resource" "get_options" {
+  depends_on = [null_resource.time_delay]
+
+  triggers = {
+    domain_name = var.domain_name
+  }
+
+  provisioner "local-exec" {
+    command = "curl -X OPTIONS 'https://${var.domain_name}/' -i > ${local.get_options}"
+  }
+}
+
+data "local_file" "get_options" {
+  depends_on = [null_resource.www_no_redirect_loop]
+
+  filename = local.get_options
+}


### PR DESCRIPTION
## Added

* Allow the HTTP OPTION method when sending request to the S3 bucket.
* Support for HTTP OPTION  method for request sent to the Lambda origin was added to the simple server.